### PR TITLE
Update adapters.sql, add WITH UR statement

### DIFF
--- a/dbt/include/ibmdb2/macros/adapters.sql
+++ b/dbt/include/ibmdb2/macros/adapters.sql
@@ -171,7 +171,7 @@ FROM SYSCAT.TABLES
 WHERE
   TABSCHEMA = '{{ schema }}' AND
   TYPE IN('T', 'V')
-
+ WITH UR
   {% endcall %}
   {{ return(load_result('list_relations_without_caching').table) }}
 {% endmacro %}


### PR DESCRIPTION
without uncommited read, it may passed the code:
RENAME xxx to xxxx__dbt_backup 
then try to run RENAME TABLE xxx__dbt_tmp TO xxx
We checked the log files and  tried to figure out the problem. So we found that the SQL(list_relations_without_caching) couldn't return a result in reasonable time. Finally we got ibm_db_dbi::ProgrammingError: Statement Execute Failed: [IBM][CLI Driver][DB2/AIX64] SQL0601N  The name of the object to be created is identical to the existing name "xxx" of type "TABLE"

If you have a lot of jobs in DB2, you may be faced of  the problem that I described. WITH UR is the solution for that problem